### PR TITLE
Work with Mender/Grav setup

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,10 +3,15 @@
 var _ = require('lodash');
 var async = require('async');
 var linkCheck = require('link-check');
+var LinkCheckResult = require('link-check/lib/LinkCheckResult')
 var markdownLinkExtractor = require('markdown-link-extractor');
 var ProgressBar = require('progress');
+var path = require('path');
+var fs = require('fs');
 
-module.exports = function markdownLinkCheck(markdown, opts, callback) {
+const dirs = p => fs.readdirSync(p).filter(f => fs.statSync(`${p}/${f}`).isDirectory())
+
+module.exports = function markdownLinkCheck(markdown, filename, opts, callback) {
     if (arguments.length === 2 && typeof opts === 'function') {
         // optional 'opts' not supplied.
         callback = opts;
@@ -24,12 +29,92 @@ module.exports = function markdownLinkCheck(markdown, opts, callback) {
         });
     }
 
-    async.mapLimit(linksCollection, 2, function (link, callback) {
+    async.mapLimit(linksCollection, 5, function (link, callback) {
+        // match links like " ../#u-boot-fw-utils" and verify the Header exists in the file
+        if (/(\.\.\/)+#/.test(link)) {
+
+          var searchDirectory = link.substr(0, link.lastIndexOf("../") + 3) + "../"
+          var headerOfInterest = link.replace(/\.\.\//g, "")
+          headerOfInterest = headerOfInterest.toLowerCase()
+          headerOfInterest = headerOfInterest.replace("#", "")
+          headerOfInterest = headerOfInterest.replace(/-/g, "\\W")
+
+          var markdownFile = path.normalize(path.join(filename, searchDirectory, "docs.md"))
+
+          fs.readFile(markdownFile, "UTF8", function(err, data) {
+            if (err) {
+
+            }
+
+            var headerRegexp = new RegExp("#+\\W" + headerOfInterest + "\\W*", "i")
+            callback(null, new LinkCheckResult(link, headerRegexp.test(data) ? 200 : 404, null));
+          });
+
+        }
+
+        // we are not testing a URL, but a relative file to another documentation page, verify
+        // that it exists.
+        else if (!(/https?:/.test(link))) {
+          /*
+            This is a little complicated, but the file structure for documentation
+            is different than the URL format used on the website.
+
+            For example, a folder: 05.Standalone-deployments will be referenced
+            as standalone-deployments in the markdown.
+
+            This code will determine what actual folder "standalone-deployments"
+            refers to.
+          */
+          if (link.startsWith("../")) {
+            var pathToCheck = "."
+            var searchDirectory = link.substr(0, link.lastIndexOf("../") + 3) + "../"
+
+            //fuzzyPath contains a path which is incorrect (missing leading digit)
+            // and is lower case.
+            var fuzzyPath = path.normalize(path.join(filename, searchDirectory, link.replace(/\.\.\//g, "")))
+
+            for (let directory of fuzzyPath.split("/")) {
+
+              // ignore anchors in paths. ex: standalone-deployments#How to deploy
+              if (directory.indexOf("#") > 0) {
+                directory = directory.substr(0, directory.indexOf("#"))
+              }
+
+              var originalPath = pathToCheck
+              pathToCheck += '/' + directory
+
+              // determine which directory matches the URL defined directory so
+              // a local directory like 05.Standalone-deployments will match
+              // standalone-deployments
+
+              if (!(fs.existsSync(pathToCheck))) {
+                for (let dir of dirs(originalPath)) {
+                  var possibleMatchingDirectory = dir.toLowerCase().replace(/^\d+\.\s*/, '')
+                  if (directory == possibleMatchingDirectory) {
+                    pathToCheck = originalPath + '/' + dir
+                  }
+                }
+              }
+            };
+
+            // make sure that the directory we found actually matches!
+           callback(null, new LinkCheckResult(link, fs.existsSync(pathToCheck) ? 200 : 404, null));
+          }
+        } else {
+
         linkCheck(link, opts, function (err, result) {
             if (opts.showProgressBar) {
                 bar.tick();
             }
+
+            // make sure localhost urls are always 'alive'
+            if (result.link.search(/localhost/) >= 0) {
+              result.status = 'alive'
+            }
+
             callback(err, result);
         });
+        }
+
     }, callback);
 };

--- a/markdown-link-check
+++ b/markdown-link-check
@@ -18,6 +18,8 @@ var statusLabels = {
 var error = false;
 var opts = {};
 var stream = process.stdin; // read from stdin unless a filename is given
+var filename = "";
+
 program.option('-p, --progress', 'show progress bar').arguments('[filenameOrUrl]').action(function (filenameOrUrl) {
     if (/https?:/.test(filenameOrUrl)) {
         stream = request.get(filenameOrUrl);
@@ -31,6 +33,7 @@ program.option('-p, --progress', 'show progress bar').arguments('[filenameOrUrl]
             opts.baseUrl = url.format(parsed);
         } catch (err) { /* ignore error */ }
     } else {
+        filename = filenameOrUrl
         opts.baseUrl = 'file://' + path.dirname(path.resolve(filenameOrUrl));
         stream = fs.createReadStream(filenameOrUrl);
     }
@@ -42,7 +45,7 @@ var markdown = ''; // collect the markdown data, then process it
 stream.on('data', function (chunk) {
     markdown += chunk.toString();
 }).on('end', function () {
-    markdownLinkCheck(markdown, opts, function (err, results) {
+    markdownLinkCheck(markdown, filename, opts, function (err, results) {
         results.forEach(function (result) {
             if(result.status === 'dead') {
                 error = true;

--- a/package.json
+++ b/package.json
@@ -33,11 +33,12 @@
     "async": "^2.1.4",
     "chalk": "^1.1.3",
     "commander": "^2.9.0",
+    "file": "^0.2.2",
     "link-check": "^4.0.2",
-    "markdown-link-extractor": "^1.1.0",
-    "request": "^2.79.0",
     "lodash": "^4.17.4",
-    "progress": "^2.0.0"
+    "markdown-link-extractor": "^1.1.0",
+    "progress": "^2.0.0",
+    "request": "^2.79.0"
   },
   "devDependencies": {
     "expect.js": "^0.3.1",


### PR DESCRIPTION
@drewmoseley @estenberg 

This tool is useful for testing that links in documentation exist without actually publishing the site first. 
I had to make quite a few modifications to support Grav's relative links.
It also checks that links to header sections (## Foobar ) exist as well.

This isn't ready for merge, but almost there! Need to fix more pressing things atm. 